### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     name: ansible-lint
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
       - run: pip install ansible-lint
       - run: ansible-lint --version
       - run: ansible-lint .


### PR DESCRIPTION
- Fix [ The "master" branch is no longer the default branch name for actions/checkout ](https://github.com/angristan/ansible-base/actions/runs/182399124) warning.

- Update setup-python to v2 (default to 3.x on x64).